### PR TITLE
Adds generic export project to PACS feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 data/
 .DS_Store
 *.csv
+/xnat-csc/scripts/export-project/venv/
+/xnat-csc/scripts/export-project/failed_to_send.txt

--- a/xnat-csc/scripts/export-project/example-config.yml
+++ b/xnat-csc/scripts/export-project/example-config.yml
@@ -1,0 +1,11 @@
+xnat:
+  user: admin
+  password: ${XNAT_PASSWORD}
+  url: http://localhost/
+  project_id: scaphoidfracturesxray
+destination:
+  name: horos
+settings:
+  delay: 3
+  attempts: 3
+  failure_log: failed_to_send.txt

--- a/xnat-csc/scripts/export-project/example-config.yml
+++ b/xnat-csc/scripts/export-project/example-config.yml
@@ -13,7 +13,7 @@ settings:
 criteria:
   inclusion:
     scan:
-      - field: series_descriptio
+      - field: series_description
         value:
           - SWI_Images
           - ax_dwi_fs_epi_DFC_TRACEW

--- a/xnat-csc/scripts/export-project/example-config.yml
+++ b/xnat-csc/scripts/export-project/example-config.yml
@@ -13,7 +13,7 @@ settings:
 criteria:
   inclusion:
     scan:
-      - field: series_description
+      - field: series_descriptio
         value:
           - SWI_Images
           - ax_dwi_fs_epi_DFC_TRACEW

--- a/xnat-csc/scripts/export-project/example-config.yml
+++ b/xnat-csc/scripts/export-project/example-config.yml
@@ -12,3 +12,19 @@ settings:
 criteria:
   inclusion:
     scan:
+      - field: series_description
+        value:
+          - SWI_Images
+          - ax_dwi_fs_epi_DFC_TRACEW
+          - ax_dwi_fs_resolve_TRACEW
+          - ax_dwi_epi_DFC_TRACEW
+          - cor_t2_flair_tse_repeat
+          - cor_t2_flair_tse_rpt
+          - sag_t2_flair_fs_space
+          - sag_t2_flair_fs_spc
+          - sag_t2_flair_tse
+          - sag_t2_fs_flair_space
+          - sag_t2_fs_flair_spc
+          - t2_FLAIR_COR
+          - ax_swi_ge3d
+          - Oblique

--- a/xnat-csc/scripts/export-project/example-config.yml
+++ b/xnat-csc/scripts/export-project/example-config.yml
@@ -9,6 +9,7 @@ settings:
   delay: 3
   attempts: 3
   failure_log: failed_to_send.txt
+  complete_log: successfully_sent.txt
 criteria:
   inclusion:
     scan:
@@ -27,4 +28,3 @@ criteria:
           - sag_t2_fs_flair_spc
           - t2_FLAIR_COR
           - ax_swi_ge3d
-          - Oblique

--- a/xnat-csc/scripts/export-project/example-config.yml
+++ b/xnat-csc/scripts/export-project/example-config.yml
@@ -9,3 +9,6 @@ settings:
   delay: 3
   attempts: 3
   failure_log: failed_to_send.txt
+criteria:
+  inclusion:
+    scan:

--- a/xnat-csc/scripts/export-project/export-to-pacs.py
+++ b/xnat-csc/scripts/export-project/export-to-pacs.py
@@ -43,6 +43,9 @@ def send_to_pacs(config):
                         try:
                             response = session.put('/xapi/dqr/export/', query={'pacsId': pacs['id'], 'session': experiment.id, 'scansToExport': scan.id})
                             logging.debug(response)
+                            if 'complete_log' in config['settings']:
+                                with open(config['settings']['complete_log'], "a") as f:
+                                    f.write(f"{subject},{experiment},{scan}\n")
                         except Exception as e:
                             last_e = e
                             logging.warning(f'RETRYING - {attempt+1}; exception: {e}')
@@ -66,6 +69,7 @@ def check_criteria(xnat_obj, criteria) -> bool:
         return True
     else:
         return False
+
 
 def parse_config_yml(yml_path):
     path_matcher = re.compile(r'\$\{([^}^{]+)}')

--- a/xnat-csc/scripts/export-project/export-to-pacs.py
+++ b/xnat-csc/scripts/export-project/export-to-pacs.py
@@ -1,0 +1,84 @@
+import argparse
+import re
+import os
+import xnat
+import tqdm
+import logging
+import time
+import yaml
+
+logging.basicConfig(level=logging.INFO)
+
+
+def send_to_pacs(config):
+
+    with xnat.connect(server=config['xnat']['url'],
+                      user=config['xnat']['user'],
+                      password=config['xnat']['password'],
+                      verify=config['xnat']['verify'] if 'verify' in config['xnat'] else False,
+                      loglevel='ERROR',
+                      ) as session:
+
+        logging.info(f'Opened XNAT Session: {session}')
+        pacs_list = session.get_json('/xapi/pacs/')
+        pacs = [x for x in pacs_list if x['label'] == config['destination']['name']][0]
+
+        project = session.projects[config['xnat']['project_id']]
+
+        for subject in project.subjects.values():
+            logging.debug(f'Subject: {subject}')
+            # Add subject level inclusion/exclusion criteria here
+            for experiment in subject.experiments.values():
+                logging.debug(f'\tExperiment: {experiment}')
+                # Add experiment level inclusion/exclusion criteria here
+                for scan in experiment.scans.values():
+                    logging.debug(f'\tScan: {experiment}')
+                    # Add scan level inclusion/exclusion criteria here
+                    for attempt in range(config['settings']['attempts']):
+                        try:
+                            response = session.put('/xapi/dqr/export/', query={'pacsId': pacs['id'], 'session': experiment.id, 'scansToExport': scan.id})
+                            logging.debug(response)
+                        except Exception as e:
+                            last_e = e
+                            logging.warning(f'RETRYING - {attempt+1}; exception: {e}')
+                        else:
+                            break
+                        finally:
+                            time.sleep(config['settings']['delay'])
+                    else:
+                        logging.warning(f"FAILED after {config['settings']['attempts']} attempts: {subject}, {experiment}, {scan}; exception: {last_e}")
+                        if 'failure_log' in config['settings']:
+                            with open(config['settings']['failure_log'], "a") as f:
+                                f.write(f"{subject},{experiment},{scan},{last_e}\n")
+
+
+def parse_config_yml(yml_path):
+    path_matcher = re.compile(r'\$\{([^}^{]+)}')
+
+    def path_constructor(loader, node):
+        """ Extract the matched value, expand env variable, and replace the match """
+        value = node.value
+        match = path_matcher.match(value)
+        env_var = match.group()[2:-1]
+        return os.environ.get(env_var) + value[match.end():]
+
+    yaml.add_implicit_resolver('!path', path_matcher, None, yaml.SafeLoader)
+    yaml.add_constructor('!path', path_constructor, yaml.SafeLoader)
+
+    with open(yml_path, "r") as stream:
+        try:
+            conf = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+    return conf
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Send XNAT project to a PACS destination')
+    parser.add_argument('config', metavar='N', type=str, help='Path to config file describing project (yml)')
+    args = parser.parse_args()
+
+    config = parse_config_yml(args.config)
+
+    send_to_pacs(config)

--- a/xnat-csc/scripts/export-project/export-to-pacs.py
+++ b/xnat-csc/scripts/export-project/export-to-pacs.py
@@ -2,7 +2,7 @@ import argparse
 import re
 import os
 import xnat
-import tqdm
+from tqdm import tqdm
 import logging
 import time
 import yaml
@@ -25,7 +25,7 @@ def send_to_pacs(config):
 
         project = session.projects[config['xnat']['project_id']]
 
-        for subject in project.subjects.values():
+        for subject in tqdm(project.subjects.values()):
             logging.debug(f'Subject: {subject}')
             # Add subject level inclusion/exclusion criteria here
             for experiment in subject.experiments.values():

--- a/xnat-csc/scripts/export-project/requirements.txt
+++ b/xnat-csc/scripts/export-project/requirements.txt
@@ -1,0 +1,3 @@
+xnat
+pyyaml
+tqdm


### PR DESCRIPTION
Had a few cases where we needed to go through every scan in an XNAT project and send them to an external dicom node (XNAT pacs destination).

This PR adds a hopefully generic version which is configured for separate projects by passing a yaml formatted config file.

Ideally, we expand the functionality of the function and add addition config options to fine-tune the export - for example inclusion/exclusion criteria.  

e.g. 

### config.yml
```yml
xnat:
  user: admin
  password: ${XNAT_PASSWORD}
  url: http://localhost/
  project_id: scaphoidfracturesxray
destination:
  name: horos
settings:
  delay: 3
  attempts: 3
  failure_log: failed_to_send.txt
criteria:
  inclusion:
    scan:
      - field: series_description
        value:
          - SWI_Images
          - ax_dwi_fs_epi_DFC_TRACEW
```

Excecuted by running:

`python export-to-pacs.py config.yml`

This will try all the values listed under `value` against the scan object's `field` property and if any of the results are true the scan is sent. 

Current known limitations (can be fixed with updates by me or anyone):
- only works with inclusion criteria
- inclusion criteria must exist (even if empty)
- not any documentation beyond this PR post
- inclusion criteria only tested and implemented at scan level - need to add experiment and subject level too

